### PR TITLE
Fix timeout bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 - Unreleased
+
+* Fixed bug that was causing the action to fail when `timeout` or `additional-files` were unspecified
+
 ## 0.1 - 2022-02-13
 
 * Initial release

--- a/action.yml
+++ b/action.yml
@@ -1,31 +1,36 @@
 name: 'Assess with PyBryt'
 description: 'Run automated assessment of a repository with PyBryt'
-branding:
-  icon: bar-chart
-  color: blue
+
 inputs:
   submission-path:
     description: 'The path to the submission'
     required: true
+
   references:
     description: 'Paths or URLs of reference implementations'
     required: true
+
   additional-files:
     description: 'Paths to additional files to trace'
     required: false
+
   timeout:
     description: 'Notebook execution timeout in seconds'
     required: false
+
 outputs:
   report-path:
     description: Path to a text file containing PyBryt's report
     value: ${{ steps.run-pybryt-script.outputs.report-path }}
+
   results-path:
     description: Path to a file containing a pickled list of results objects
     value: ${{ steps.run-pybryt-script.outputs.results-path }}
+
   student-implementation-path:
     description: Path to a file containing the pickled student implementation
     value: ${{ steps.run-pybryt-script.outputs.student-implementation-path }}
+
 runs:
   using: 'composite'
   steps:

--- a/run_pybryt.py
+++ b/run_pybryt.py
@@ -11,10 +11,10 @@ import validators
 
 
 PARSER = argparse.ArgumentParser()
-PARSER.add_argument("--additional-files")
+PARSER.add_argument("--additional-files", nargs="?", default=None)
 PARSER.add_argument("--references")
 PARSER.add_argument("--subm")
-PARSER.add_argument("--timeout")
+PARSER.add_argument("--timeout", nargs="?", default=None)
 
 
 is_none = lambda s: s.lower() == "none"


### PR DESCRIPTION
Fixes a bug in the `timeout` and `additional-files` arguments that was causing the action to error if they were unspecified.